### PR TITLE
Update "sega.s" on "sgdk-skeleton" example

### DIFF
--- a/examples/sgdk-skeleton/boot/sega.s
+++ b/examples/sgdk-skeleton/boot/sega.s
@@ -42,15 +42,15 @@ _Vecteurs_68K:
         dc.l    _INT,_INT,_INT,_INT,_INT,_INT,_INT,_INT
         dc.l    _INT,_INT,_INT,_INT,_INT,_INT,_INT,_INT
 
-_Rom_Header:
-		/* .incbin "boot/rom_head.bin", 0x10, 0x100 */
         .incbin "boot/rom_head.bin"
 
 _Entry_Point:
         move    #0x2700,%sr
         tst.l   0xa10008
         bne.s   SkipJoyDetect
+
         tst.w   0xa1000c
+
 SkipJoyDetect:
         bne.s   SkipSetup
 
@@ -61,6 +61,7 @@ SkipJoyDetect:
         move.b  -0x10ff(%a1),%d0
         andi.b  #0x0f,%d0
         beq.s   WrongVersion
+
 * Sega Security Code (SEGA)
         move.l  #0x53454741,0x2f00(%a1)
 WrongVersion:
@@ -70,45 +71,18 @@ WrongVersion:
         move    %a6,%usp
         move.w  %d7,(%a1)
         move.w  %d7,(%a2)
-        jmp     _hard_reset
 
-Table:
-        dc.w    0x8000,0x3fff,0x0100
-        dc.l    0xA00000,0xA11100,0xA11200,0xC00000,0xC00004
+* Jump to initialisation process now...
+
+        jmp     _start_entry
 
 SkipSetup:
         jmp     _reset_entry
 
-_hard_reset:
-* clear Genesis RAM
-        lea     0xff0000,%a0
-        moveq   #0,%d0
-        move.w  #0x3FFF,%d1
 
-ClearRam:
-        move.l  %d0,(%a0)+
-        dbra    %d1,ClearRam
-
-* copy initialized variables from ROM to Work RAM
-        lea     _stext,%a0
-        lea     0xFF0000,%a1
-        move.l  #_sdata,%d0
-
-* fix for last byte to initialize
-        addq.l  #1,%d0
-        lsr.l   #1,%d0
-        beq     NoCopy
-
-        subq.w  #1,%d0
-CopyVar:
-        move.w  (%a0)+,(%a1)+
-        dbra    %d0,CopyVar
-
-NoCopy:
-
-* Jump to initialisation process...
-
-        jmp     _start_entry
+Table:
+        dc.w    0x8000,0x3fff,0x0100
+        dc.l    0xA00000,0xA11100,0xA11200,0xC00000,0xC00004
 
 
 *------------------------------------------------
@@ -246,24 +220,40 @@ _INT:
 
 _EXTINT:
         movem.l %d0-%d1/%a0-%a1,-(%sp)
-        move.l  internalExtIntCB, %a0
+        move.l  eintCB, %a0
         jsr    (%a0)
         movem.l (%sp)+,%d0-%d1/%a0-%a1
         rte
 
 _HINT:
         movem.l %d0-%d1/%a0-%a1,-(%sp)
-        move.l  internalHIntCB, %a0
+        move.l  hintCB, %a0
         jsr    (%a0)
         movem.l (%sp)+,%d0-%d1/%a0-%a1
         rte
 
 _VINT:
         movem.l %d0-%d1/%a0-%a1,-(%sp)
-        move.l  internalVIntCB, %a0
-        jsr    (%a0)
+        ori.w   #0x0001, intTrace           /* in V-Int */
+        addq.l  #1, vtimer                  /* increment frame counter (more a vint counter) */
+        btst    #3, VBlankProcess+1         /* PROCESS_XGM_TASK ? (use VBlankProcess+1 as btst is a byte operation) */
+        beq.s   _no_xgm_task
+
+        jsr     XGM_doVBlankProcess         /* do XGM vblank task */
+
+_no_xgm_task:
+        btst    #1, VBlankProcess+1         /* PROCESS_BITMAP_TASK ? (use VBlankProcess+1 as btst is a byte operation) */
+        beq.s   _no_bmp_task
+
+        jsr     BMP_doVBlankProcess         /* do BMP vblank task */
+
+_no_bmp_task:
+        move.l  vintCB, %a0                 /* load user callback */
+        jsr    (%a0)                        /* call user callback */
+        andi.w  #0xFFFE, intTrace           /* out V-Int */
         movem.l (%sp)+,%d0-%d1/%a0-%a1
         rte
+
 
 *------------------------------------------------
 *


### PR DESCRIPTION
Toolchain built recently with newest sgdk 1.60 + newlib
There are differences between example's `sega.s` and the latest from SGDK project.
This PR aims to update it (probably the same is needed for the other sgdk examples).

### Troubleshoot

When running the example's make I was getting linker errors when compiling main:

```bash
/opt/marsdev/m68k-elf/bin/m68k-elf-gcc -o out.elf -T /opt/marsdev/ldscripts/sgdk.ld \
  -nostdlib boot/sega.o res/resources.o src/main.o   -L/opt/marsdev/m68k-elf/lib/gcc/m68k-elf/9.3.0 -lgcc \
  -L/opt/marsdev/m68k-elf/m68k-elf/lib -lnosys \
  -u __modsi3 -u __divsi3 -u __mulsi3 -u __umodsi3 -u __udivsi3 -u __umulsi3 \
  -L/opt/marsdev/m68k-elf/lib -lmd
  
/opt/marsdev/m68k-elf/bin/../lib/gcc/m68k-elf/9.3.0/../../../../m68k-elf/bin/ld: boot/sega.o: in function `_EXTINT':
(.text.keepboot+0x44e): undefined reference to `internalExtIntCB'
/opt/marsdev/m68k-elf/bin/../lib/gcc/m68k-elf/9.3.0/../../../../m68k-elf/bin/ld: boot/sega.o: in function `_HINT':
(.text.keepboot+0x460): undefined reference to `internalHIntCB'
/opt/marsdev/m68k-elf/bin/../lib/gcc/m68k-elf/9.3.0/../../../../m68k-elf/bin/ld: boot/sega.o: in function `_VINT':
(.text.keepboot+0x472): undefined reference to `internalVIntCB'
collect2: error: ld returned 1 exit status
make: *** [out.elf] Error 1
```

Checking the symbols from sgdk library, I couldn't find anything related to those:

```bash
which nm
/opt/marsdev/m68k-elf/m68k-elf/bin/nm

nm --plugin=$MARSDEV/m68k-elf/libexec/gcc/m68k-elf/9.3.0/liblto_plugin.so \
  -n $MARSDEV/m68k-elf/lib/libmd.a 2>/dev/null | grep -c internal
0
```

Checked Stef's "sega.s" and there were several differences. He refactored the code and the functions differ:

```bash
nm --plugin=$MARSDEV/m68k-elf/libexec/gcc/m68k-elf/9.3.0/liblto_plugin.so \
  -n $MARSDEV/m68k-elf/lib/libmd.a 2>/dev/null | grep intCB
00000000 c eintCB
00000000 c hintCB
00000000 c intCB
00000000 c vintCB
```

I just copied it and modified the `incbin` line, as the example's Makefile compiles on `boot/` instead of `out/`.
Now it succeeded. The rom opens on blastem with no issues as well:

```bash
AS boot/rom_head.bin
java -jar /opt/marsdev/bin/rescomp.jar res/resources.res res/resources.s
ResComp 3.1 - SGDK Resource Compiler - Copyright 2020 (Stephane Dallongeville)

Resource: IMAGE moon "moon.bmp" 0
--> executing plugin IMAGE...'moon' raw size: 1764 bytes


res/resources.res summary:
-------------
Binary data: 1728 bytes
  Unpacked: 1728 bytes
Misc metadata (bitmap, image, tilemap, tileset, palette..): 36 bytes
Total: 1764 bytes (1 KB)
AS res/resources.s
CC src/main.c
/opt/marsdev/m68k-elf/bin/m68k-elf-gcc -o out.elf -T /opt/marsdev/ldscripts/sgdk.ld -nostdlib boot/sega.o res/resources.o src/main.o   -L/opt/marsdev/m68k-elf/lib/gcc/m68k-elf/9.3.0 -lgcc -u __modsi3 -u __divsi3 -u __mulsi3 -u __umodsi3 -u __udivsi3 -u __umulsi3 -L/opt/marsdev/m68k-elf/lib -lmd
Stripping ELF header...
18+1 records in
19+0 records out
155648 bytes transferred in 0.000650 secs (239484603 bytes/sec)
/opt/marsdev/m68k-elf/bin/m68k-elf-nm --plugin=/opt/marsdev/m68k-elf/libexec/gcc/m68k-elf/9.3.0/liblto_plugin.so -n out.elf > symbol.txt
rm res/resources.s src/main.o
```