### PR TITLE
Fixes Docker, gets z80 building again, md-echo-test builds with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,26 @@ RUN apt update && \
     autoconf automake libtool libboost-dev && \
     apt clean
 
-# Grab repo and make everything
-RUN git clone https://github.com/andwn/marsdev && \
-    cd marsdev && \
-    make m68k-toolchain-newlib LANGS=c,c++ && \
-    make m68k-gdb && \
-    make sh-toolchain-newlib LANGS=c,c++ && \
-    make -C gdb ARCH=sh && \
-    make z80-tools && \
-    make sgdk && \
-    make sik-tools && \
-    make flamewing-tools && \
-    cd && rm -rf marsdev
+ENV MARSDEV=/marsdev
+ENV PATH=$PATH:$JAVA_HOME/bin
+
+WORKDIR /work
+
+RUN git clone https://github.com/andwn/marsdev
+
+WORKDIR /work/marsdev
+
+RUN make m68k-toolchain-newlib LANGS=c,c++ MARSDEV=$MARSDEV
+RUN make m68k-gdb MARSDEV=$MARSDEV
+RUN make sh-toolchain-newlib LANGS=c,c++ MARSDEV=$MARSDEV
+RUN make -C gdb ARCH=sh MARSDEV=$MARSDEV
+RUN make z80-tools MARSDEV=$MARSDEV
+RUN make sgdk MARSDEV=$MARSDEV
+RUN make sik-tools MARSDEV=$MARSDEV
+RUN make flamewing-tools MARSDEV=$MARSDEV
+
+RUN rm -rf /work
+RUN chmod ugo+r -R $MARSDEV
+RUN chmod ugo+x -R $MARSDEV/bin
+
+CMD make

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /
 RUN rm -rf /work
 RUN rm -rf /root/mars
 
-RUN echo '#!/bin/bash\njava -jar $MARSDEV/bin/rescomp.jar ${@:2}' > $MARSDEV/bin/rescomp && chmod +x $MARSDEV/bin/rescomp 
+RUN echo '#!/bin/bash\njava -Duser.dir="`pwd`" -jar $MARSDEV/bin/rescomp.jar ${@:-1}' > $MARSDEV/bin/rescomp && chmod +x $MARSDEV/bin/rescomp 
 
 RUN chmod ugo+r -R $HOME
 RUN chmod ugo+r -R $MARSDEV

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,25 +12,36 @@ RUN apt update && \
 ENV MARSDEV=/marsdev/mars
 ENV PATH=$PATH:$JAVA_HOME/bin
 ENV HOME=/marsdev
+ENV LOG=$HOME/build.log
+ENV MARSDEV_GIT=https://github.com/dleslie/marsdev
+
+RUN rm -rf $HOME $MARSDEV $LOG
+
+RUN mkdir -p $HOME
+RUN mkdir -p `dirname $LOG`
+RUN mkdir -p $MARSDEV
 
 WORKDIR /work
 
-RUN git clone https://github.com/andwn/marsdev
+# RUN git clone $MARSDEV_GIT
+COPY ./ marsdev/
 
 WORKDIR /work/marsdev
+RUN make m68k-toolchain-newlib LANGS=c,c++ MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)
+RUN make m68k-gdb MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)
+RUN make sh-toolchain-newlib LANGS=c,c++ MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)
+RUN make -C gdb ARCH=sh MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)
+RUN make z80-tools MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)
+RUN make sgdk MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)
+RUN make sik-tools MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)
+RUN make flamewing-tools MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)
 
-RUN make m68k-toolchain-newlib LANGS=c,c++ MARSDEV=$MARSDEV
-RUN make m68k-gdb MARSDEV=$MARSDEV
-RUN make sh-toolchain-newlib LANGS=c,c++ MARSDEV=$MARSDEV
-RUN make -C gdb ARCH=sh MARSDEV=$MARSDEV
-RUN make z80-tools MARSDEV=$MARSDEV
-RUN make sgdk MARSDEV=$MARSDEV
-RUN make sik-tools MARSDEV=$MARSDEV
-RUN make flamewing-tools MARSDEV=$MARSDEV
+WORKDIR /
 
 RUN rm -rf /work
 RUN rm -rf /root/mars
 
+RUN chmod ugo+r -R $HOME
 RUN chmod ugo+r -R $MARSDEV
 RUN chmod ugo+x -R $MARSDEV/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV MARSDEV=/marsdev/mars
 ENV PATH=$PATH:$JAVA_HOME/bin
 ENV HOME=/marsdev
 ENV LOG=$HOME/build.log
-ENV MARSDEV_GIT=https://github.com/dleslie/marsdev
+#ENV MARSDEV_GIT=https://github.com/dleslie/marsdev
+ENV MARSDEV_GIT=https://github.com/andwn/marsdev
 
 RUN rm -rf $HOME $MARSDEV $LOG
 
@@ -23,8 +24,8 @@ RUN mkdir -p $MARSDEV
 
 WORKDIR /work
 
-# RUN git clone $MARSDEV_GIT
-COPY ./ marsdev/
+RUN git clone $MARSDEV_GIT
+#COPY ./ marsdev/
 
 WORKDIR /work/marsdev
 RUN make m68k-toolchain-newlib LANGS=c,c++ MARSDEV=$MARSDEV 2>&1 | (tee -a $LOG)

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN make sik-tools MARSDEV=$MARSDEV
 RUN make flamewing-tools MARSDEV=$MARSDEV
 
 RUN rm -rf /work
+RUN rm -rf /root/mars
+
 RUN chmod ugo+r -R $MARSDEV
 RUN chmod ugo+x -R $MARSDEV/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt update && \
     apt clean
 
 ENV MARSDEV=/marsdev/mars
+ENV GENDEV=$MARSDEV
 ENV PATH=$PATH:$JAVA_HOME/bin
 ENV HOME=/marsdev
 ENV LOG=$HOME/build.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ RUN apt update && \
     autoconf automake libtool libboost-dev && \
     apt clean
 
-ENV MARSDEV=/marsdev
+ENV MARSDEV=/marsdev/mars
 ENV PATH=$PATH:$JAVA_HOME/bin
+ENV HOME=/marsdev
 
 WORKDIR /work
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ WORKDIR /
 RUN rm -rf /work
 RUN rm -rf /root/mars
 
+RUN echo '#!/bin/bash\njava -jar $MARSDEV/bin/rescomp.jar ${@:2}' > $MARSDEV/bin/rescomp && chmod +x $MARSDEV/bin/rescomp 
+
 RUN chmod ugo+r -R $HOME
 RUN chmod ugo+r -R $MARSDEV
 RUN chmod ugo+x -R $MARSDEV/bin

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ z80-toolchain:
 
 z80-tools:
 	make -C z80-tools
-	
+
 sik-tools:
 	make -C sik-tools
 
@@ -40,7 +40,7 @@ flamewing-tools:
 
 sgdk:
 	make -C sgdk SGDK_VER=v1.60
-	
+
 sgdk-legacy:
 	make -C sgdk SGDK_VER=v1.33
 

--- a/z80-tools/Makefile
+++ b/z80-tools/Makefile
@@ -40,8 +40,8 @@ $(Z80ASM): $(MARSBIN)
 	# One of the tests fails so we just skip them
 	# echo "all:\n\t@echo skipping tests" > z80asm/tests/Makefile
 	# It also doesn't link libintl anymore...why
-	sed -i $(SED_FIX) "s/LDFLAGS =/LDFLAGS = -lintl/g" z80asm/Makefile
-	make -C z80asm
+	sed -i $(SED_FIX) "s/LDFLAGS =/LDFLAGS = -lintl/g" Makefile
+	make
 	cp -f z80asm/src/z80asm $(Z80ASM)
 
 $(MARSBIN):

--- a/z80-tools/Makefile
+++ b/z80-tools/Makefile
@@ -20,8 +20,7 @@ endif
 
 .PHONY: all clean
 
-all: $(SJASM) 
-#$(Z80ASM)
+all: $(SJASM) $(Z80ASM)
 
 $(SJASM): $(MARSBIN)
 	rm -rf sjasm
@@ -36,7 +35,7 @@ $(Z80ASM): $(MARSBIN)
 	git clone https://git.savannah.nongnu.org/git/z80asm.git
 	cd z80asm && autoreconf -f -i && ./configure
 	# One of the tests fails so we just skip them
-	echo "all:\n\t@echo skipping tests" > z80asm/tests/Makefile
+	# echo "all:\n\t@echo skipping tests" > z80asm/tests/Makefile
 	# It also doesn't link libintl anymore...why
 	sed -i $(SED_FIX) "s/LDFLAGS =/LDFLAGS = -lintl/g" z80asm/Makefile
 	make -C z80asm

--- a/z80-tools/Makefile
+++ b/z80-tools/Makefile
@@ -3,6 +3,9 @@ MARSBIN = $(MARSDEV)/bin
 SJASM   = $(MARSBIN)/sjasm
 Z80ASM  = $(MARSBIN)/z80asm
 
+Z80REV = 99b216126b0879c78c157f547475c6ba28583d4a
+SJBRANCH = v0.39
+
 # Use homebrew's gettext on macOS, for autopoint
 ifeq ($(OS),Windows_NT)
 else
@@ -24,7 +27,7 @@ all: $(SJASM) $(Z80ASM)
 
 $(SJASM): $(MARSBIN)
 	rm -rf sjasm
-	git clone https://github.com/konamiman/sjasm --branch v0.39
+	git clone https://github.com/konamiman/sjasm --branch $(SJBRANCH)
 	# There's mismatching caps in the Makefile for sjasm
 	#mv sjasm/Sjasm/Sjasm.cpp sjasm/Sjasm/sjasm.cpp
 	cd sjasm/Sjasm && make
@@ -33,7 +36,7 @@ $(SJASM): $(MARSBIN)
 $(Z80ASM): $(MARSBIN)
 	rm -rf z80asm
 	git clone https://git.savannah.nongnu.org/git/z80asm.git
-	cd z80asm && autoreconf -f -i && ./configure
+	cd z80asm && git checkout $(Z80REV) && autoreconf -f -i && ./configure
 	# One of the tests fails so we just skip them
 	# echo "all:\n\t@echo skipping tests" > z80asm/tests/Makefile
 	# It also doesn't link libintl anymore...why

--- a/z80-tools/Makefile
+++ b/z80-tools/Makefile
@@ -40,7 +40,7 @@ $(Z80ASM): $(MARSBIN)
 	# One of the tests fails so we just skip them
 	# echo "all:\n\t@echo skipping tests" > z80asm/tests/Makefile
 	# It also doesn't link libintl anymore...why
-	sed -i $(SED_FIX) "s/LDFLAGS =/LDFLAGS = -lintl/g" Makefile
+	sed -i $(SED_FIX) "s/LDFLAGS =/LDFLAGS = -lintl/g" z80asm/Makefile
 	make -C z80asm
 	cp -f z80asm/src/z80asm $(Z80ASM)
 

--- a/z80-tools/Makefile
+++ b/z80-tools/Makefile
@@ -41,7 +41,7 @@ $(Z80ASM): $(MARSBIN)
 	# echo "all:\n\t@echo skipping tests" > z80asm/tests/Makefile
 	# It also doesn't link libintl anymore...why
 	sed -i $(SED_FIX) "s/LDFLAGS =/LDFLAGS = -lintl/g" Makefile
-	make
+	make -C z80asm
 	cp -f z80asm/src/z80asm $(Z80ASM)
 
 $(MARSBIN):


### PR DESCRIPTION
I put some time in this week to get the Dockerfile for marsdev up and going.

The changes break it up into smaller chunks so that it can cache more effectively, along with setting permissions and such so that executing as an unprivileged user doesn't write files to the host as root.

All said and done, it appears that `md-echo-test` now compiles once again.