### PR TITLE
Fix SUSE lib64 issue

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -76,7 +76,9 @@ mk-binutils:
 	@echo "+++ Building $(BINUTILS_DIR) for $(ARCH)..."
 	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && \
-		../configure --target=$(TARGET) --prefix=$(PREFIX) $(CPU_ARGS) \
+		../configure --target=$(TARGET) --prefix=$(PREFIX) \
+		--libdir=$(MARSDEV)/$(TARGET)/lib --libexecdir=$(MARSDEV)/$(TARGET)/libexec \
+		$(CPU_ARGS) \
 		--enable-install-libbfd --enable-shared=no --disable-nls --disable-werror \
 		> $(LOGDIR)/binutils-$(ARCH).log 2>&1
 	make -C $(BUILD_DIR) all install-strip \
@@ -90,9 +92,11 @@ mk-gcc:
 	@echo "+++ Building $(GCC_DIR) for $(ARCH)..."
 	cd $(GCC_DIR) && ./contrib/download_prerequisites \
 		> $(LOGDIR)/gcc-$(ARCH).log 2>&1
+	patch -p0 < libcc1_suse_fix.patch
 	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && \
 		../configure --target=$(TARGET) --prefix=$(PREFIX) \
+		--libdir=$(MARSDEV)/$(TARGET)/lib --libexecdir=$(MARSDEV)/$(TARGET)/libexec \
 		--enable-languages=c $(CPU_ARGS) \
 		--without-headers --disable-libssp \
 		--disable-threads --disable-tls --disable-multilib \
@@ -109,7 +113,9 @@ mk-newlib:
 	@echo "+++ Building $(NEWLIB_DIR) for $(ARCH)..."
 	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && \
-		../configure --target=$(TARGET) --prefix=$(PREFIX) $(CPU_ARGS) \
+		../configure --target=$(TARGET) --prefix=$(PREFIX) \
+		--libdir=$(MARSDEV)/$(TARGET)/lib --libexecdir=$(MARSDEV)/$(TARGET)/libexec \
+		$(CPU_ARGS) \
 		--disable-multilib --disable-nls --disable-werror \
 		> $(LOGDIR)/newlib-$(ARCH).log 2>&1
 	make -C $(BUILD_DIR) all install \
@@ -124,6 +130,7 @@ mk-gcc2:
 	@mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR) && \
 		../configure --target=$(TARGET) --prefix=$(PREFIX) \
+	   	--libdir=$(MARSDEV)/$(TARGET)/lib --libexecdir=$(MARSDEV)/$(TARGET)/libexec \
 		--enable-languages=$(LANGS) $(CPU_ARGS) \
 		--without-headers --with-newlib --disable-libssp \
 		--disable-libstacktrace --disable-libstdcxx \

--- a/toolchain/libcc1_suse_fix.patch
+++ b/toolchain/libcc1_suse_fix.patch
@@ -1,0 +1,29 @@
+Philipp Seiler <p.seiler@linuxmail.org>
+
+This is a workaround as `c++ -print-multi-os-directory` outputs
+`../lib64` for openSUSE as this is the default directory for libraries.
+But marsdev uses lib. This is caused by the libsuffix variable set by
+the libcc1 configure script.
+
+openSUSE:
+${HOME}/mars/m68k-elf/lib/../lib64 
+
+correct:
+${HOME}/mars/m68k-elf/lib/../lib
+
+So this reomves the suffix at all which results in:
+${HOME}/mars/m68k-elf/lib
+
+
+--- gcc-10.3.0/libcc1/configure.bak	2022-01-23 19:37:32.844442081 +0100
++++ gcc-10.3.0/libcc1/configure	2022-01-23 19:37:43.432540501 +0100
+@@ -14664,9 +14664,6 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
+ libsuffix=
+-if test "$GXX" = yes; then
+-  libsuffix=`$CXX -print-multi-os-directory`
+-fi
+ 
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for socket libraries" >&5


### PR DESCRIPTION
openSUSE has lib64 as default directory for it's 64bit libraries.
This affects the build of marsdev on this platform. Fedora should
be the same.

More details in the patch header where it's described a bit more detailed.