### PR TITLE
More Docker and Build Changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,18 +27,20 @@ WORKDIR /work/marsdev
 RUN make LANGS=c,c++ MARSDEV=$MARSDEV flamewing-tools
 RUN make LANGS=c,c++ MARSDEV=$MARSDEV z80-tools
 RUN make LANGS=c,c++ MARSDEV=$MARSDEV sik-tools
-RUN make LANGS=c,c++ MARSDEV=$MARSDEV m68k-toolchain
-RUN make LANGS=c,c++ MARSDEV=$MARSDEV sh-toolchain
-RUN make LANGS=c,c++ MARSDEV=$MARSDEV m68k-toolchain-newlib
-RUN make LANGS=c,c++ MARSDEV=$MARSDEV sh-toolchain-newlib
+
+RUN make LANGS=c,c++ MARSDEV=$MARSDEV m68k-toolchain clean
+RUN make LANGS=c,c++ MARSDEV=$MARSDEV m68k-toolchain-newlib clean
 RUN make LANGS=c,c++ MARSDEV=$MARSDEV m68k-gdb
-RUN make LANGS=c,c++ MARSDEV=$MARSDEV sh-gdb
+
 RUN make LANGS=c,c++ MARSDEV=$MARSDEV sgdk
+
+RUN make LANGS=c,c++ MARSDEV=$MARSDEV sh-toolchain clean
+RUN make LANGS=c,c++ MARSDEV=$MARSDEV sh-toolchain-newlib clean
+RUN make LANGS=c,c++ MARSDEV=$MARSDEV sh-gdb
 
 WORKDIR /
 
-RUN rm -rf /work
-RUN rm -rf /root/mars
+RUN rm -rf /work /root/mars
 
 RUN echo '#!/bin/bash\njava -Duser.dir="`pwd`" -jar $MARSDEV/bin/rescomp.jar ${@:-1}' > $MARSDEV/bin/rescomp && chmod +x $MARSDEV/bin/rescomp 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ ENV GENDEV=$MARSDEV
 ENV PATH=$PATH:$JAVA_HOME/bin
 ENV HOME=/marsdev
 ENV LOG=$HOME/build.log
-ENV MARSDEV_GIT=https://github.com/andwn/marsdev
 
 RUN mkdir -p $HOME
 RUN mkdir -p `dirname $LOG`
@@ -22,7 +21,6 @@ RUN mkdir -p $MARSDEV
 
 WORKDIR /work
 
-#RUN git clone $MARSDEV_GIT marsdev
 COPY ./ marsdev/
 
 WORKDIR /work/marsdev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM ubuntu:jammy as build
+FROM debian:bookworm-slim as build
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
 RUN apt update && \
     apt install -y git build-essential texinfo curl wget \
-    openjdk-8-jdk-headless libpng-dev cmake libboost-all-dev \
+    openjdk-17-jdk-headless libpng-dev cmake libboost-all-dev \
     autoconf automake libtool libboost-dev && \
     apt clean
 

--- a/sik-tools/Makefile
+++ b/sik-tools/Makefile
@@ -53,8 +53,8 @@ $(PCM2EWF): mdtools $(MARSBIN)
 	cp -f mdtools/pcm2ewf/tool/pcm2ewf $(PCM2EWF)
 
 $(ECHO2VGM): mdtools $(MARSBIN)
-	# echo2vgm fails to compile in Windows
-	if [ $(OS) != Windows_NT ]; then \
+# echo2vgm fails to compile in Windows
+	if [ "$(OS)" != Windows_NT ]; then \
 		$(MAKE) -C mdtools/echo2vgm; \
 		cp -f mdtools/echo2vgm/echo2vgm $(ECHO2VGM); \
 	fi

--- a/z80-tools/Makefile
+++ b/z80-tools/Makefile
@@ -1,11 +1,29 @@
 TOOLSBIN = $(MARSDEV)/bin
 
 SJASM   = $(TOOLSBIN)/sjasm
+Z80ASM  = $(TOOLSBIN)/z80asm
+
+Z80REV = 99b216126b0879c78c157f547475c6ba28583d4a
 SJBRANCH = v0.39
+
+# Use homebrew's gettext on macOS, for autopoint
+ifeq ($(OS),Windows_NT)
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		export PATH := /usr/local/opt/gettext/bin:$(PATH)
+	endif
+endif
+
+# OSX sed fails without the '', and GNU fails with, coolbeans
+SED_FIX=
+ifeq ($(shell uname -s),Darwin)
+	SED_FIX=''
+endif
 
 .PHONY: all clean
 
-all: $(SJASM)
+all: $(SJASM) $(Z80ASM)
 
 $(SJASM): $(TOOLSBIN)
 	rm -rf sjasm
@@ -13,8 +31,19 @@ $(SJASM): $(TOOLSBIN)
 	cd sjasm/Sjasm && $(MAKE)
 	cp -f sjasm/Sjasm/sjasm $(SJASM)
 
+$(Z80ASM): $(TOOLSBIN)
+	rm -rf z80asm
+	git clone https://git.savannah.nongnu.org/git/z80asm.git
+	cd z80asm && git checkout $(Z80REV) && autoreconf -f -i && ./configure
+# One of the tests fails so we just skip them
+# echo "all:\n\t@echo skipping tests" > z80asm/tests/Makefile
+# It also doesn't link libintl anymore...why
+	sed -i $(SED_FIX) "s/LDFLAGS =/LDFLAGS = -lintl/g" z80asm/Makefile
+	make -C z80asm
+	cp -f z80asm/src/z80asm $(Z80ASM)
+
 $(TOOLSBIN):
 	mkdir -p $(TOOLSBIN)
 
 clean:
-	rm -rf sjasm
+	rm -rf sjasm z80asm

--- a/z80-tools/Makefile
+++ b/z80-tools/Makefile
@@ -23,7 +23,11 @@ endif
 
 .PHONY: all clean
 
+ifeq ($(UNAME_S),Darwin)
+all: $(SJASM)
+else
 all: $(SJASM) $(Z80ASM)
+endif
 
 $(SJASM): $(TOOLSBIN)
 	rm -rf sjasm


### PR DESCRIPTION
This is a slew of changes for Docker and general building

- Switched to using debian slim with a named release, to prevent future issues with rolling releases
- z80asm compiles properly for Docker builds, it remains disabled for OSX
- sik tools now build in Docker; they didn't before because `$(OS)` was an empty string
- Some cleanup and order changes

I anticipate more to come, when I have the time. I'm trying to get all the examples I've collected here to build: 
https://github.com/dleslie/genesis-dev