### PR TITLE
fix docker april 2024

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,63 @@
-FROM ubuntu:jammy as build
+FROM debian:bookworm-slim as build_env
 
 ARG DEBIAN_FRONTEND=noninteractive
+
+ENV MARS_BUILD_DIR=/marsdev/build
+ENV MARS_INSTALL_DIR=/marsdev/mars
+ENV GENDEV=$MARS_INSTALL_DIR
+ENV PATH=$PATH:$JAVA_HOME/bin
+ENV HOME=/marsdev
 
 # Install prerequisites
 RUN apt update && \
     apt install -y git build-essential texinfo wget \
-    openjdk-17-jdk-headless libpng-dev \
-    && apt clean
+    openjdk-17-jdk-headless libpng-dev && \
+    apt clean && \
+    mkdir -p $MARS_BUILD_DIR && \
+    mkdir -p $MARS_INSTALL_DIR/bin
 
-ENV MARSDEV=/marsdev/mars
-ENV GENDEV=$MARSDEV
-ENV PATH=$PATH:$JAVA_HOME/bin
-ENV HOME=/marsdev
-ENV LOG=$HOME/build.log
+COPY ./ $MARS_BUILD_DIR
+WORKDIR $MARS_BUILD_DIR
 
-RUN mkdir -p $HOME
-RUN mkdir -p `dirname $LOG`
-RUN mkdir -p $MARSDEV
-RUN mkdir -p $MARSDEV/bin
+FROM build_env as build_m68k_toolchain
 
-WORKDIR /work
+RUN make m68k-toolchain-newlib
 
-COPY ./ marsdev/
+FROM build_m68k_toolchain as build_sh_toolchain
 
-WORKDIR /work/marsdev
+RUN make sh-toolchain-newlib
 
-FROM build as build_toolchain
+FROM build_sh_toolchain as build_sgdk
 
-#RUN make MARS_BUILD_DIR=$MARSDEV m68k-toolchain clean
-RUN make MARS_BUILD_DIR=$MARSDEV m68k-toolchain-newlib
+RUN make sgdk
 
-#RUN make MARS_BUILD_DIR=$MARSDEV sh-toolchain clean
-RUN make MARS_BUILD_DIR=$MARSDEV sh-toolchain-newlib
+FROM build_sgdk as build_x68k_tools
 
-FROM build_env as build_sgdk
-
-RUN make MARS_BUILD_DIR=$MARSDEV sgdk
-
-FROM build_toolchain as build_x68k_tools
-
-RUN make MARS_BUILD_DIR=$MARSDEV x68k-tools
+RUN make x68k-tools
 
 FROM build_x68k_tools as build_sik_tools
 
-RUN make MARS_BUILD_DIR=$MARSDEV sik-tools
+RUN make sik-tools
 
-FROM build_sik_tools as build_finish
+FROM build_sik_tools as build_install
+
+RUN make install
+
+# Hack to run rescomp
+RUN echo '#!/bin/bash\njava -Duser.dir="`pwd`" -jar $MARS_INSTALL_DIR/bin/rescomp.jar ${@:-1}' > $MARS_INSTALL_DIR/bin/rescomp && chmod +x $MARS_INSTALL_DIR/bin/rescomp
+
+FROM build_install as build_final
 
 WORKDIR /
 
-RUN rm -rf /work /root/mars
+RUN rm -rf /work $MARS_BUILD_DIR && \
+    chmod ugo+r -R $HOME && \
+    chmod ugo+r -R $MARS_INSTALL_DIR && \
+    chmod ugo+rx -R $MARS_INSTALL_DIR/mars.sh && \
+    chmod ugo+rx -R $MARS_INSTALL_DIR/bin && \
+    chmod ugo+rx -R $MARS_INSTALL_DIR/m68k-elf/bin && \
+    chmod ugo+rx -R $MARS_INSTALL_DIR/sh-elf/bin && \
+    echo "exec \"\$@\"" >> /marsdev/mars/mars.sh
 
-RUN echo '#!/bin/bash\njava -Duser.dir="`pwd`" -jar $MARSDEV/bin/rescomp.jar ${@:-1}' > $MARSDEV/bin/rescomp && chmod +x $MARSDEV/bin/rescomp
-
-RUN chmod ugo+r -R $HOME
-RUN chmod ugo+r -R $MARSDEV
-RUN chmod ugo+x -R $MARSDEV/bin
-
+ENTRYPOINT ["/marsdev/mars/mars.sh"]
 CMD make

--- a/sgdk/Makefile
+++ b/sgdk/Makefile
@@ -102,8 +102,7 @@ $(SJASM):
 	mkdir -p $(BIN)
 	rm -rf sjasm
 	git clone https://github.com/konamiman/sjasm --depth=1 --branch $(SJBRANCH)
-	cd sjasm/Sjasm && $(MAKE)
-	cp -f sjasm $(SJASM)
+	cd sjasm/Sjasm && $(MAKE) && cp -f sjasm $(SJASM)
 
 $(BINTOS): SGDK
 	gcc SGDK/tools/bintos/src/bintos.c -o $@

--- a/sgdk/Makefile
+++ b/sgdk/Makefile
@@ -99,10 +99,11 @@ samples: SGDK $(GDK)/lib/libmd.a
 # Tools
 
 $(SJASM):
+	mkdir -p $(BIN)
 	rm -rf sjasm
 	git clone https://github.com/konamiman/sjasm --depth=1 --branch $(SJBRANCH)
 	cd sjasm/Sjasm && $(MAKE)
-	cp -f sjasm/Sjasm/sjasm $(SJASM)
+	cp -f sjasm $(SJASM)
 
 $(BINTOS): SGDK
 	gcc SGDK/tools/bintos/src/bintos.c -o $@


### PR DESCRIPTION
Probably fixes #42 

The remaining issue is that `ldscripts` doesn't seem to be included in either the repo or any of the locations it pulls from; I'm not sure why those scripts were removed, but now the `32x-skeleton` refuses to compile.

@andwn could you advise regarding the missing ldscripts?